### PR TITLE
Feature/typescript port

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,0 @@
-require("@nomicfoundation/hardhat-toolbox");
-
-/** @type import('hardhat/config').HardhatUserConfig */
-module.exports = {
-  solidity: "0.8.18",
-};

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,17 @@
+import { HardhatUserConfig } from 'hardhat/config'
+require('@nomicfoundation/hardhat-toolbox')
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: '0.8.18',
+    settings: {
+      viaIR: true,
+      optimizer: {
+        enabled: true,
+        runs: 1000,
+      },
+    },
+  },
+}
+
+export default config;

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ interface NoncePairs {
   readonly kTwoPublic: Uint8Array,
 }
 
-interface PublicNonces {
+export interface PublicNonces {
   readonly kPublic: Uint8Array,
   readonly kTwoPublic: Uint8Array,
 }
@@ -230,7 +230,7 @@ export class Schnorrkel {
     }
   }
 
-  sumSigs(sigs: string[]): string {
+  sumSigs(sigs: Uint8Array[]): Uint8Array {
     var combined = getBigi().fromBuffer(sigs[0]);
     sigs.shift();
     sigs.map(sig => {
@@ -239,7 +239,7 @@ export class Schnorrkel {
     return combined.mod(n).toBuffer(32);
   }
 
-  verify(s: string, msg: string, R: Uint8Array, publicKey: Uint8Array): boolean {
+  verify(s: Uint8Array, msg: string, R: Uint8Array, publicKey: Uint8Array): boolean {
     const hash = this.#hashMessage(msg)
     const eC = this.#challenge(R, hash, publicKey)
     const sG = generatorPoint.mul(ethers.utils.arrayify(s))

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.2.0",
         "chai": "^4.3.7",
+        "chai-assertions-count": "^1.0.2",
         "hardhat": "^2.13.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.4"
@@ -2864,6 +2865,15 @@
       },
       "peerDependencies": {
         "chai": ">= 2.1.2 < 5"
+      }
+    },
+    "node_modules/chai-assertions-count": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chai-assertions-count/-/chai-assertions-count-1.0.2.tgz",
+      "integrity": "sha512-TnhoI68Mh7GYsdrvQuxK+kKOTfEXQZjePP8lTvYhXGv8KOKY+GaOY3PemMq8mBAa0gqQRKsISdi7QFJ/Lxdt+g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "*"
       }
     },
     "node_modules/chalk": {
@@ -11589,6 +11599,13 @@
       "requires": {
         "check-error": "^1.0.2"
       }
+    },
+    "chai-assertions-count": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chai-assertions-count/-/chai-assertions-count-1.0.2.tgz",
+      "integrity": "sha512-TnhoI68Mh7GYsdrvQuxK+kKOTfEXQZjePP8lTvYhXGv8KOKY+GaOY3PemMq8mBAa0gqQRKsISdi7QFJ/Lxdt+g==",
+      "dev": true,
+      "requires": {}
     },
     "chalk": {
       "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,13 @@
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
-        "hardhat": "^2.13.0"
+        "@types/chai": "^4.3.5",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^20.2.0",
+        "chai": "^4.3.7",
+        "hardhat": "^2.13.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -24,7 +30,6 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -718,7 +723,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -727,15 +731,13 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1938,29 +1940,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@typechain/ethers-v5": {
       "version": "10.2.0",
@@ -2054,11 +2052,10 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true,
-      "peer": true
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
     },
     "node_modules/@types/chai-as-promised": {
       "version": "7.1.5",
@@ -2118,13 +2115,12 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+      "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
       "dev": true
     },
     "node_modules/@types/pbkdf2": {
@@ -2201,7 +2197,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2214,7 +2209,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2365,8 +2359,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2470,7 +2463,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2848,7 +2840,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -2904,7 +2895,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3269,8 +3259,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -3336,7 +3325,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -4749,7 +4737,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6035,7 +6022,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
       "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -6059,8 +6045,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/markdown-table": {
       "version": "1.1.3",
@@ -6752,7 +6737,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8750,7 +8734,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8794,7 +8777,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8854,7 +8836,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8953,11 +8934,10 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9072,8 +9052,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -9490,7 +9469,6 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9514,7 +9492,6 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
@@ -9908,22 +9885,19 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -10868,29 +10842,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@typechain/ethers-v5": {
       "version": "10.2.0",
@@ -10962,11 +10932,10 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true,
-      "peer": true
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
     },
     "@types/chai-as-promised": {
       "version": "7.1.5",
@@ -11026,13 +10995,12 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+      "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
       "dev": true
     },
     "@types/pbkdf2": {
@@ -11102,15 +11070,13 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "address": {
       "version": "1.2.2",
@@ -11221,8 +11187,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -11304,8 +11269,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -11606,7 +11570,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -11649,8 +11612,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -11953,8 +11915,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "crypt": {
       "version": "0.0.2",
@@ -12000,7 +11961,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -13132,8 +13092,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.2.0",
@@ -14090,7 +14049,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
       "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -14114,8 +14072,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "markdown-table": {
       "version": "1.1.3",
@@ -14642,8 +14599,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -16183,7 +16139,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16204,8 +16159,7 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -16257,8 +16211,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",
@@ -16329,11 +16282,10 @@
       "peer": true
     },
     "typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
-      "dev": true,
-      "peer": true
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",
@@ -16417,8 +16369,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -16752,8 +16703,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@borislav.itskov/schnorrkel.js",
   "version": "1.0.2",
   "description": "",
-  "main": "index.js",
+  "main": "index.ts",
   "scripts": {
     "test": "hardhat test"
   },
@@ -20,6 +20,12 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
-    "hardhat": "^2.13.0"
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^20.2.0",
+    "chai": "^4.3.7",
+    "hardhat": "^2.13.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.2.0",
     "chai": "^4.3.7",
+    "chai-assertions-count": "^1.0.2",
     "hardhat": "^2.13.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"

--- a/signers/DefaultSigner.ts
+++ b/signers/DefaultSigner.ts
@@ -1,5 +1,6 @@
-const { ethers, config } = require("hardhat");
-const Schnorrkel = require("../index")
+import { config, ethers } from "hardhat";
+import { Schnorrkel } from "..";
+
 const schnorrkel = new Schnorrkel();
 const secp256k1 = require('secp256k1')
 
@@ -14,7 +15,7 @@ module.exports = class DefaultSigner {
   }
 
   #generatePrivateKey(index) {
-    const accounts = config.networks.hardhat.accounts
+    const accounts: any = config.networks.hardhat.accounts
     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${index}`)
     return ethers.utils.arrayify(wallet.privateKey);
   }
@@ -28,7 +29,6 @@ module.exports = class DefaultSigner {
   }
 
   multiSignMessage(msg, publicKeys, publicNonces) {
-    const x  = this.#privateKey;
-    return schnorrkel.multiSigSign(x, msg, publicKeys, publicNonces);
+    return schnorrkel.multiSigSign(this.#privateKey, msg, publicKeys, publicNonces);
   }
 }

--- a/signers/DefaultSigner.ts
+++ b/signers/DefaultSigner.ts
@@ -1,34 +1,33 @@
 import { config, ethers } from "hardhat";
-import { Schnorrkel } from "..";
-
+import secp256k1 from 'secp256k1'
+import { PublicNonces, Schnorrkel } from "..";
 const schnorrkel = new Schnorrkel();
-const secp256k1 = require('secp256k1')
 
-module.exports = class DefaultSigner {
+export class DefaultSigner {
 
-  #privateKey;
-  #publicKey;
+  #privateKey: Uint8Array;
+  #publicKey: Uint8Array;
 
-  constructor(index) {
+  constructor(index: number) {
     this.#privateKey = this.#generatePrivateKey(index)
     this.#publicKey = secp256k1.publicKeyCreate(this.#privateKey);
   }
 
-  #generatePrivateKey(index) {
+  #generatePrivateKey(index: number): Uint8Array {
     const accounts: any = config.networks.hardhat.accounts
     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${index}`)
     return ethers.utils.arrayify(wallet.privateKey);
   }
 
-  getPublicKey() {
+  getPublicKey(): Uint8Array {
     return this.#publicKey;
   }
 
-  getPublicNonces() {
+  getPublicNonces(): PublicNonces {
     return schnorrkel.generatePublicNonces(this.#privateKey);
   }
 
-  multiSignMessage(msg, publicKeys, publicNonces) {
+  multiSignMessage(msg: string, publicKeys: Uint8Array[], publicNonces: PublicNonces[]) {
     return schnorrkel.multiSigSign(this.#privateKey, msg, publicKeys, publicNonces);
   }
 }

--- a/test/JsWorks.js
+++ b/test/JsWorks.js
@@ -1,0 +1,65 @@
+const { ethers, config } = require('hardhat');
+const secp256k1 = require('secp256k1')
+const ERC1271_MAGICVALUE_BYTES32 = '0x1626ba7e';
+const { Schnorrkel } = require('..');
+const schnorrkel = new Schnorrkel();
+
+const {
+  loadFixture,
+} = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+
+describe('Js test', function () {
+  const entryPoint = '0x0000000000000000000000000000000000000000';
+  async function deployContract() {
+    const SchnorrAccountAbstraction = await ethers.getContractFactory('SchnorrAccountAbstraction');
+
+    // the private key
+    const accounts = config.networks.hardhat.accounts
+    const accountIndex = 0
+    const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${accountIndex}`)
+    const privateKey = ethers.utils.arrayify(wallet.privateKey);
+
+    // the eth address
+    const publicKey = secp256k1.publicKeyCreate(privateKey);
+    const px = publicKey.slice(1, 33);
+    const pxGeneratedAddress = ethers.utils.hexlify(px);
+    const address = '0x' + pxGeneratedAddress.slice(pxGeneratedAddress.length - 40, pxGeneratedAddress.length);
+
+    // deploying the contract
+    const contract = await SchnorrAccountAbstraction.deploy(entryPoint, [address]);
+    const isSigner = await contract.canSign(address);
+    expect(isSigner).to.equal('0x0000000000000000000000000000000000000000000000000000000000000001');
+
+    return { contract };
+  }
+
+  it('should load the files in a js file and work', async function () {
+    const { contract } = await loadFixture(deployContract);
+
+    // get the public key
+    const accounts = config.networks.hardhat.accounts
+    const accountIndex = 0
+    const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${accountIndex}`)
+    const privateKey = ethers.utils.arrayify(wallet.privateKey);
+    const publicKey = secp256k1.publicKeyCreate(privateKey);
+
+    // sign
+    const msg = 'just a test message';
+    const sig = schnorrkel.sign(privateKey, msg);
+
+    // wrap the result
+    const px = publicKey.slice(1, 33);
+    const parity = publicKey[0] - 2 + 27;
+    const abiCoder = new ethers.utils.AbiCoder();
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
+      px,
+      sig.e,
+      sig.s,
+      parity
+    ]);
+    const msgHash = ethers.utils.solidityKeccak256(['string'], [msg]);
+    const result = await contract.isValidSignature(msgHash, sigData);
+    expect(result).to.equal(ERC1271_MAGICVALUE_BYTES32);
+  })
+});

--- a/test/MultiSigTest.ts
+++ b/test/MultiSigTest.ts
@@ -1,8 +1,9 @@
+import { Schnorrkel } from "..";
+const schnorrkel = new Schnorrkel()
+
 const { ethers } = require("hardhat");
 const ERC1271_MAGICVALUE_BYTES32 = "0x1626ba7e";
 const DefaultSigner = require('../signers/DefaultSigner')
-const Schnorrkel = require("../index")
-const schnorrkel = new Schnorrkel()
 
 const {
   loadFixture,

--- a/test/MultiSigTest.ts
+++ b/test/MultiSigTest.ts
@@ -1,24 +1,19 @@
-import { Schnorrkel } from "..";
-const schnorrkel = new Schnorrkel()
-
-const { ethers } = require("hardhat");
-const ERC1271_MAGICVALUE_BYTES32 = "0x1626ba7e";
-const DefaultSigner = require('../signers/DefaultSigner')
-import chai from 'chai';
+import { Schnorrkel } from '..';
+import chai, { expect } from 'chai';
 import chaiAssertionsCount from 'chai-assertions-count';
+import { DefaultSigner } from '../signers/DefaultSigner';
+import { ethers } from 'hardhat';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 chai.use(chaiAssertionsCount);
+const schnorrkel = new Schnorrkel()
+const ERC1271_MAGICVALUE_BYTES32 = '0x1626ba7e';
 
-const {
-  loadFixture,
-} = require("@nomicfoundation/hardhat-network-helpers");
-const { expect } = require("chai");
-
-describe("Multi Sign Tests", function () {
-  const entryPoint = "0x0000000000000000000000000000000000000000";
+describe('Multi Sign Tests', function () {
+  const entryPoint = '0x0000000000000000000000000000000000000000';
   async function deployContract() {
 
     // Contracts are deployed using the first signer/account by default
-    const SchnorrAccountAbstraction = await ethers.getContractFactory("SchnorrAccountAbstraction");
+    const SchnorrAccountAbstraction = await ethers.getContractFactory('SchnorrAccountAbstraction');
 
     // get the public key
     const signerOne = new DefaultSigner(0);
@@ -34,7 +29,7 @@ describe("Multi Sign Tests", function () {
     return { contract };
   }
 
-  it("should generate a schnorr musig2 and validate it on the blockchain", async function () {
+  it('should generate a schnorr musig2 and validate it on the blockchain', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -54,7 +49,7 @@ describe("Multi Sign Tests", function () {
 
     // wrap the result
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       e,
       sSummed,
@@ -65,7 +60,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal(ERC1271_MAGICVALUE_BYTES32);
   })
 
-  it("should fail if the signer is totally different", async function () {
+  it('should fail if the signer is totally different', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -86,7 +81,7 @@ describe("Multi Sign Tests", function () {
 
     // wrap the result
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       e,
       sSummed,
@@ -97,7 +92,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal('0xffffffff');
   })
 
-  it("should fail if only one signature is provided", async function () {
+  it('should fail if only one signature is provided', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -115,7 +110,7 @@ describe("Multi Sign Tests", function () {
 
     // wrap the result
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       e,
       sigOne,
@@ -126,7 +121,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal('0xffffffff');
   })  
 
-  it("should fail if a signer tries to sign twice with the same nonce", async function () {
+  it('should fail if a signer tries to sign twice with the same nonce', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -139,7 +134,7 @@ describe("Multi Sign Tests", function () {
     expect(signerOne.multiSignMessage.bind(signerOne, msg, publicKeys, publicNonces)).to.throw('Nonces should be exchanged before signing');
   })
 
-  it("should fail if only one signer tries to sign the transaction providing 2 messages", async function () {
+  it('should fail if only one signer tries to sign the transaction providing 2 messages', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -161,7 +156,7 @@ describe("Multi Sign Tests", function () {
 
     // wrap the result
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       e,
       sSummed,
@@ -172,7 +167,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal('0xffffffff');
   })
 
-  it("should generate a schnorr musig2 and validate it offchain", async function () {
+  it('should generate a schnorr musig2 and validate it offchain', async function () {
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
     const msg = 'just a test message';
@@ -186,7 +181,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal(true);
   })
 
-  it("should successfully pass even if the order of the public keys is different", async function () {
+  it('should successfully pass even if the order of the public keys is different', async function () {
     // deploy the contract
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);
@@ -206,7 +201,7 @@ describe("Multi Sign Tests", function () {
 
     // wrap the result
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       e,
       sSummed,
@@ -217,7 +212,7 @@ describe("Multi Sign Tests", function () {
     expect(result).to.equal(ERC1271_MAGICVALUE_BYTES32);
   })
 
-  it("should throw error requirements for public keys when generating nonces and multi singatures", async function () {
+  it('should throw error requirements for public keys when generating nonces and multi singatures', async function () {
     chai.Assertion.expectExpects(3);
     const signerOne = new DefaultSigner(0);
     const signerTwo = new DefaultSigner(1);

--- a/test/SingleSignTest.js
+++ b/test/SingleSignTest.js
@@ -1,7 +1,7 @@
 const { ethers, config } = require("hardhat");
 const secp256k1 = require('secp256k1')
 const ERC1271_MAGICVALUE_BYTES32 = "0x1626ba7e";
-const Schnorrkel = require('../index.js');
+const { Schnorrkel } = require("..");
 const schnorrkel = new Schnorrkel();
 
 const {

--- a/test/SingleSignTest.js
+++ b/test/SingleSignTest.js
@@ -46,7 +46,7 @@ describe("Single Sign Tests", function () {
 
     // sign
     const msg = 'just a test message';
-    const sig = schnorrkel.sign(msg, privateKey);
+    const sig = schnorrkel.sign(privateKey, msg);
 
     // wrap the result
     const px = publicKey.slice(1, 33);
@@ -73,7 +73,7 @@ describe("Single Sign Tests", function () {
 
     // get the message
     const msg = 'just a test message';
-    const {R, s} = schnorrkel.sign(msg, privateKey);
+    const {R, s} = schnorrkel.sign(privateKey, msg);
     const result = schnorrkel.verify(s, msg, R, publicKey);
     expect(result).to.equal(true);
   })

--- a/test/SingleSignTest.ts
+++ b/test/SingleSignTest.ts
@@ -1,21 +1,18 @@
-const { ethers, config } = require("hardhat");
-const secp256k1 = require('secp256k1')
-const ERC1271_MAGICVALUE_BYTES32 = "0x1626ba7e";
-const { Schnorrkel } = require("..");
+import { config, ethers } from 'hardhat';
+import secp256k1 from 'secp256k1'
+import { Schnorrkel } from '..'
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai';
+const ERC1271_MAGICVALUE_BYTES32 = '0x1626ba7e';
 const schnorrkel = new Schnorrkel();
 
-const {
-  loadFixture,
-} = require("@nomicfoundation/hardhat-network-helpers");
-const { expect } = require("chai");
-
-describe("Single Sign Tests", function () {
-  const entryPoint = "0x0000000000000000000000000000000000000000";
+describe('Single Sign Tests', function () {
+  const entryPoint = '0x0000000000000000000000000000000000000000';
   async function deployContract() {
-    const SchnorrAccountAbstraction = await ethers.getContractFactory("SchnorrAccountAbstraction");
+    const SchnorrAccountAbstraction = await ethers.getContractFactory('SchnorrAccountAbstraction');
 
     // the private key
-    const accounts = config.networks.hardhat.accounts
+    const accounts: any = config.networks.hardhat.accounts
     const accountIndex = 0
     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${accountIndex}`)
     const privateKey = ethers.utils.arrayify(wallet.privateKey);
@@ -24,7 +21,7 @@ describe("Single Sign Tests", function () {
     const publicKey = secp256k1.publicKeyCreate(privateKey);
     const px = publicKey.slice(1, 33);
     const pxGeneratedAddress = ethers.utils.hexlify(px);
-    const address = "0x" + pxGeneratedAddress.slice(pxGeneratedAddress.length - 40, pxGeneratedAddress.length);
+    const address = '0x' + pxGeneratedAddress.slice(pxGeneratedAddress.length - 40, pxGeneratedAddress.length);
 
     // deploying the contract
     const contract = await SchnorrAccountAbstraction.deploy(entryPoint, [address]);
@@ -34,11 +31,11 @@ describe("Single Sign Tests", function () {
     return { contract };
   }
 
-  it("should generate a schnorr signature and verify onchain", async function () {
+  it('should generate a schnorr signature and verify onchain', async function () {
     const { contract } = await loadFixture(deployContract);
 
     // get the public key
-    const accounts = config.networks.hardhat.accounts
+    const accounts: any = config.networks.hardhat.accounts
     const accountIndex = 0
     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${accountIndex}`)
     const privateKey = ethers.utils.arrayify(wallet.privateKey);
@@ -52,7 +49,7 @@ describe("Single Sign Tests", function () {
     const px = publicKey.slice(1, 33);
     const parity = publicKey[0] - 2 + 27;
     const abiCoder = new ethers.utils.AbiCoder();
-    const sigData = abiCoder.encode([ "bytes32", "bytes32", "bytes32", "uint8" ], [
+    const sigData = abiCoder.encode([ 'bytes32', 'bytes32', 'bytes32', 'uint8' ], [
       px,
       sig.e,
       sig.s,
@@ -63,9 +60,9 @@ describe("Single Sign Tests", function () {
     expect(result).to.equal(ERC1271_MAGICVALUE_BYTES32);
   })
 
-  it("should generate a schnorr signature and verify offchain", async function () {
+  it('should generate a schnorr signature and verify offchain', async function () {
     // get the Private key
-    const accounts = config.networks.hardhat.accounts
+    const accounts: any = config.networks.hardhat.accounts
     const accountIndex = 0
     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${accountIndex}`)
     const privateKey = ethers.utils.arrayify(wallet.privateKey);


### PR DESCRIPTION
This PR ships all the javascript into typescript. It should be working with regular javascript, just the import path for the Schnorr class needs to change. 

Minor changes:
* when generating generatePublicNonces, the private key is hashed before put as a key in the array
* a requirement of at least 2 public keys for the multisig has been placed and an error returned if not present
* interfaced types
* clearing the nonces deletes the cached key as well

Breaking changes:
* the parameters passed to `sign` change places for code consistency
* `generatePublicNonces` method returns the nonces no longer as an array but as `PublicNonces` interfaced object. 