### PR TITLE
fix: make sure sorting works as expected

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -177,7 +177,7 @@ const internalVerify = (s: Uint8Array, hash: string, R: Uint8Array, publicKey: U
 }
 
 export const _generateL = (publicKeys: Array<Uint8Array>) => {
-  return ethers.utils.keccak256(_concatTypedArrays(publicKeys.sort()))
+  return ethers.utils.keccak256(_concatTypedArrays(publicKeys.sort(Buffer.compare)))
 }
 
 export const _concatTypedArrays = (publicKeys: Uint8Array[]): Uint8Array => {

--- a/tests/core/_generateL.test.ts
+++ b/tests/core/_generateL.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { _generateL } from '../../src/core'
+
+describe('testing _generateL', () => {
+  it('should get the expected hash for L even if public keys switch places (test if sorting works correctly)', () => {
+    const publicKeyOne = Buffer.from('02e823a040a5602776959fe78ce3e1856dd1f9ae3a113da602854c98bd67fafd8f','hex')
+    const publicKeyTwo = Buffer.from('02946ef03de338aed83037c2d344114c64f5cef75ffc498b0854dabdb98a3a8fc9', 'hex');
+
+    const lHash = _generateL([publicKeyOne, publicKeyTwo])
+    const lHashSorted = _generateL([publicKeyTwo, publicKeyOne])
+
+    expect(lHash).toEqual('0x5862551eb4dc671b6127b8234ce5eb443b55dc4f334566a7a9e7e5c17ee6bd92')
+    expect(lHashSorted).toEqual('0x5862551eb4dc671b6127b8234ce5eb443b55dc4f334566a7a9e7e5c17ee6bd92')
+  })
+})


### PR DESCRIPTION
Hi, thank you for working on this library which benefits our team a lot!

While working on the schnorr signature, we've found the step for generating L is not working as expected for some cases. In this function, we need to sort the public keys first, and this is where makes the result incorrect.
Since the public keys in `publicKeys` array are actually Buffer instead of Uint8Array, we need to compare them through `Buffer.compare` ([ref](https://nodejs.org/api/buffer.html#static-method-buffercomparebuf1-buf2)). Otherwise, the public keys are not actually sorted correctly.

## TBD
Also, this raises another topic that maybe we should make sure that the type is declared correspondingly as `Array<Buffer>`, or that `publicKeys` is actually composed of Uint8Array. I wonder what'd be your preference as I saw the type of it was `Array<Buffer>` before, then changed to `Array<Uint8Array>` in https://github.com/borislav-itskov/schnorrkel.js/commit/eb4ae06956f751da11b8cf2b4238479cafbe4319